### PR TITLE
feat: update staker scripts to v0.1.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -10,7 +10,7 @@
   "upstream": [
     {
       "repo": "dappnode/staker-package-scripts",
-      "version": "v0.1.0",
+      "version": "v0.1.2",
       "arg": "STAKER_SCRIPTS_VERSION"
     }
   ],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         UPSTREAM_VERSION: v1.3.12
         KEYPER_CONFIG_DIR: /keyper/config
         SHUTTER_CHAIN_DIR: /chain
-        STAKER_SCRIPTS_VERSION: v0.1.0
+        STAKER_SCRIPTS_VERSION: v0.1.2
     restart: unless-stopped
     environment:
       - SHUTTER_API_NODE_PRIVATEKEY=""

--- a/shutter/scripts/configure_keyper.sh
+++ b/shutter/scripts/configure_keyper.sh
@@ -16,11 +16,14 @@ PATH=$NODE_HOME/bin:$PATH
 function test_ethereum_url() {
     # FIXME: This is a workaround for the issue with the staker-scripts@v0.1.1 not setting get_execution_ws_url_from_global_env correctly in the environment variables.
     # Git Issue: https://github.com/dappnode/staker-package-scripts/issues/11
-    export SHUTTER_NETWORK_NODE_ETHEREUMURL=${ETHEREUM_WS:-$(get_execution_ws_url_from_global_env ${NETWORK} ${SUPPORTED_NETWORKS})}
+    export SHUTTER_NETWORK_NODE_ETHEREUMURL=${ETHEREUM_WS:-$(get_execution_ws_url_from_global_env ${NETWORK})}
+    echo "[DEBUG | configure] SHUTTER_NETWORK_NODE_ETHEREUMURL is ${SHUTTER_NETWORK_NODE_ETHEREUMURL}"
     RESULT=$(wscat -c "$SHUTTER_NETWORK_NODE_ETHEREUMURL" -x '{"jsonrpc": "2.0", "method": "eth_syncing", "params": [], "id": 1}')
+    echo "[DEBUG | configure] RESULT is ${RESULT}"
     if [[ $RESULT =~ '"id":1' ]]; then return 0; else
-        export SHUTTER_NETWORK_NODE_ETHEREUMURL=ws://execution.${NETWORK}.dncore.dappnode:8545
+        export SHUTTER_NETWORK_NODE_ETHEREUMURL=ws://execution.${NETWORK}.dncore.dappnode:8546
         RESULT=$(wscat -c "$SHUTTER_NETWORK_NODE_ETHEREUMURL" -x '{"jsonrpc": "2.0", "method": "eth_syncing", "params": [], "id": 1}')
+        echo "[DEBUG | configure] RESULT is ${RESULT}"
         if [[ $RESULT =~ '"id":1' ]]; then return 0; else
             echo "Could not find DAppNode RPC/WS url for this package!"
             echo "Please configure 'ETHEREUM_WS' to point to an applicable websocket RPC service."

--- a/shutter/scripts/configure_keyper.sh
+++ b/shutter/scripts/configure_keyper.sh
@@ -14,16 +14,11 @@ NODE_PATH=$NODE_HOME/lib/node_modules
 PATH=$NODE_HOME/bin:$PATH
 
 function test_ethereum_url() {
-    # FIXME: This is a workaround for the issue with the staker-scripts@v0.1.1 not setting get_execution_ws_url_from_global_env correctly in the environment variables.
-    # Git Issue: https://github.com/dappnode/staker-package-scripts/issues/11
     export SHUTTER_NETWORK_NODE_ETHEREUMURL=${ETHEREUM_WS:-$(get_execution_ws_url_from_global_env ${NETWORK})}
-    echo "[DEBUG | configure] SHUTTER_NETWORK_NODE_ETHEREUMURL is ${SHUTTER_NETWORK_NODE_ETHEREUMURL}"
     RESULT=$(wscat -c "$SHUTTER_NETWORK_NODE_ETHEREUMURL" -x '{"jsonrpc": "2.0", "method": "eth_syncing", "params": [], "id": 1}')
-    echo "[DEBUG | configure] RESULT is ${RESULT}"
     if [[ $RESULT =~ '"id":1' ]]; then return 0; else
-        export SHUTTER_NETWORK_NODE_ETHEREUMURL=ws://execution.${NETWORK}.dncore.dappnode:8546
+        export SHUTTER_NETWORK_NODE_ETHEREUMURL=ws://execution.${NETWORK}.dncore.dappnode:8545 #letting it default to the old URL, incase the node running on the dappnode is not updated to the new version
         RESULT=$(wscat -c "$SHUTTER_NETWORK_NODE_ETHEREUMURL" -x '{"jsonrpc": "2.0", "method": "eth_syncing", "params": [], "id": 1}')
-        echo "[DEBUG | configure] RESULT is ${RESULT}"
         if [[ $RESULT =~ '"id":1' ]]; then return 0; else
             echo "Could not find DAppNode RPC/WS url for this package!"
             echo "Please configure 'ETHEREUM_WS' to point to an applicable websocket RPC service."


### PR DESCRIPTION
the staker scripts v0.1.2 uses default port as 8546(new nethermind node port).
https://github.com/dappnode/staker-package-scripts/blob/main/scripts/dvt_lsd_tools.sh#L16