### PR TITLE
Update assets to shutter-api-gnosis-1002-set1.1.1

### DIFF
--- a/package_variants/gnosis/docker-compose.yml
+++ b/package_variants/gnosis/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         CHAIN_PORT: 27656
         KEYPER_PORT: 24003
         KEYPER_METRICS_PORT: 9100
-        ASSETS_VERSION: shutter-api-gnosis-1002-set1.1.0
+        ASSETS_VERSION: shutter-api-gnosis-1002-set1.1.1
     ports:
       - "24003:24003"
       - "27656:27656"
@@ -18,4 +18,4 @@ services:
     build:
       args:
         NETWORK: gnosis
-        ASSETS_VERSION: shutter-api-gnosis-1002-set1.1.0
+        ASSETS_VERSION: shutter-api-gnosis-1002-set1.1.1


### PR DESCRIPTION
This includes a change that increases the `MaxNumKeysPerMessage` setting.

See https://github.com/shutter-network/shutter-keyper-assets/pull/18 for details.